### PR TITLE
[Laksh] Perform interaction action on all components of similar type on a GameObject.

### DIFF
--- a/Assets/AriumFramework/Interaction.cs
+++ b/Assets/AriumFramework/Interaction.cs
@@ -24,14 +24,17 @@ namespace AriumFramework
 
         public void PerformAction(GameObject gameObject)
         {
-            T component = gameObject.GetComponent<T>();
+            var components = gameObject.GetComponents<T>();
             
-            if (component == null)
+            if (components.Length == 0)
             {
                 throw new ComponentNotFoundException(gameObject, typeof(T));
             }
-            
-            _action.Invoke(component);
+
+            foreach (var component in components)
+            {
+                _action?.Invoke(component);
+            }
         }
     }
 }


### PR DESCRIPTION
In this fix: interaction action on multiple similar(base type) components attached a GameObject will get called.
Previously the interaction action was happening only on the first component that matches the type rather than all the components which match the base type attached to GameObject.